### PR TITLE
Solving missing 'data' directory in gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ tmp
 .yardoc
 _yardoc
 doc/
-data/*
 lib/*.bundle

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I get some errors with that, `evaluator.cf` was not created due to missing `data` directory.
